### PR TITLE
Removed inspect.lua

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "inspect.lua"]
-	path = inspect.lua
-	url = https://github.com/kikito/inspect.lua.git


### PR DESCRIPTION
This submodule turned out to be unnecessary. Use 'display()' instead to pretty-print a lua table in mudlet.
