### PR TITLE
Event system

### DIFF
--- a/forestbot.lua
+++ b/forestbot.lua
@@ -46,7 +46,14 @@ end
 -- Evaluate the behaviour tree based on the current known state of the world.
 --------------------------------------------------------------------------------
 function bot.think()
-  -- dispatch behaviour tree
+  bot.debugMessage("Thinking...")
+end
+
+--------------------------------------------------------------------------------
+-- Run bot.think() after all triggers have finished for the current line.
+--------------------------------------------------------------------------------
+function bot.thinkAfterTriggers()
+  tempTimer(0, [[bot.think()]])
 end
 
 --------------------------------------------------------------------------------
@@ -128,6 +135,7 @@ end
 --------------------------------------------------------------------------------
 -- Function to register an event handler with Mudlet's event system
 -- Stores registered handlers in the bot.handlers namespace.
+-- All events include bot.thinkAfterTriggers as a handler.
 -- We guarantee that only one event will be fired per line from the mud.
 --------------------------------------------------------------------------------
 function bot.addHandler(eventName, handlerName, handlerFunc)
@@ -135,6 +143,7 @@ function bot.addHandler(eventName, handlerName, handlerFunc)
   " to handle \"" .. eventName .. "\" event.")
   bot.handlers[handlerName] = handlerFunc
   registerAnonymousEventHandler(eventName, "bot.handlers." .. handlerName)
+  registerAnonymousEventHandler(eventName, "bot.thinkAfterTriggers")
 end
 
 --------------------------------------------------------------------------------

--- a/forestbot.lua
+++ b/forestbot.lua
@@ -75,6 +75,9 @@ function bot.reset()
   bot.status.xp = 0
 
   bot.status.stance = ""
+  
+  bot.location = {}
+  bot.location.roomNo = 0
 
   bot.needs = {}
   bot.needs.hunger = 0
@@ -257,6 +260,13 @@ function bot.initHandlers()
   bot.addHandler("botDeath", "botCombatDeath",
   function()
     bot.combat.removeAllTargets()
+  end
+  )
+
+  bot.addHandler("newRoom", "updateRoomNumber",
+  function(event, roomNo)
+    bot.location.roomNo = roomNo
+    bot.debugMessage("Currently in room #".. bot.location.roomNo)
   end
   )
 end

--- a/forestbot.lua
+++ b/forestbot.lua
@@ -85,6 +85,7 @@ function bot.reset()
   bot.items.hasWater = true
 
   bot.items.inventory = {}
+  bot.items.equipment = {}
 
   bot.combat.targets = {}
 
@@ -132,6 +133,14 @@ function bot.functions.updateInventory()
 end
 
 --------------------------------------------------------------------------------
+-- Enable equipment parsing triggers and request equipment from the mud.
+--------------------------------------------------------------------------------
+function bot.functions.updateEquipment()
+  enableTrigger("refresh equipment")
+  send("equipment")
+end
+
+--------------------------------------------------------------------------------
 -- Function to register an event handler with Mudlet's event system
 -- Stores registered handlers in the bot.handlers namespace.
 -- All events include bot.thinkAfterTriggers as a handler.
@@ -175,6 +184,12 @@ function bot.initHandlers()
   bot.addHandler("inventoryUpdated", "inventory",
   function()
     bot.debugMessage("Implement inventory update handler.")
+  end
+  )
+
+  bot.addHandler("equipmentUpdated", "equipment",
+  function()
+    bot.debugMessage("Implement equipment update handler.")
   end
   )
 

--- a/forestbot.lua
+++ b/forestbot.lua
@@ -8,21 +8,18 @@
 -- Central bot namespace
 --------------------------------------------------------------------------------
 bot = {}
+bot.handlers = {}
 bot.functions = {}
 bot.debug = true
-
-if bot.debug then
-  bot.debugMessage = print
-else
-  bot.debugMessage = function(s) end
-end
 
 --------------------------------------------------------------------------------
 -- Initializer function.  Will be executed when this script file is loaded.
 --------------------------------------------------------------------------------
 function bot.init()
   if bot.debug then
-    bot.debugMessage = print
+    bot.debugMessage = function(s)
+      print(">> " .. s)
+    end
   else
     bot.debugMessage = function(s) end
   end
@@ -41,6 +38,7 @@ function bot.init()
   package.loaded["behaviourtree.behaviourtree"] = nil
   behaviourtree = require("behaviourtree.behaviourtree")
 
+  bot.initHandlers()
   bot.reset()
 end
 
@@ -82,7 +80,7 @@ function bot.reset()
   bot.items.hasFood = true 
   bot.items.hasWater = true
 
-  bot.inventory = {}
+  bot.items.inventory = {}
 
   -- should probably init inventory here
   -- and stats
@@ -123,8 +121,78 @@ end
 -- Enable inventory parsing triggers and request inventory from the mud.
 --------------------------------------------------------------------------------
 function bot.functions.updateInventory()
-  enableTrigger("request_inventory")
+  enableTrigger("refresh inventory")
   send("inventory")
+end
+
+--------------------------------------------------------------------------------
+-- Function to register an event handler with Mudlet's event system
+-- Stores registered handlers in the bot.handlers namespace.
+-- We guarantee that only one event will be fired per line from the mud.
+--------------------------------------------------------------------------------
+function bot.addHandler(eventName, handlerName, handlerFunc)
+  bot.debugMessage("Adding bot.handlers." .. handlerName ..
+  " to handle \"" .. eventName .. "\" event.")
+  bot.handlers[handlerName] = handlerFunc
+  registerAnonymousEventHandler(eventName, "bot.handlers." .. handlerName)
+end
+
+--------------------------------------------------------------------------------
+-- Function to remove an event handler
+-- As of Feb 2016, Mudlet's event system cannot unregister an event handler,
+-- so we instead change the lua function registered as a handler to a no-op.
+--------------------------------------------------------------------------------
+function bot.removeHandler(eventName, handlerName)
+  bot.handlers[handlerName] = function() end
+end
+
+--------------------------------------------------------------------------------
+-- Handlers for triggered events
+--------------------------------------------------------------------------------
+function bot.initHandlers()
+  bot.addHandler("hungerEvent", "hunger",
+  function(eventName, hungerLevel)
+    bot.debugMessage("Setting bot.needs.hunger to " .. hungerLevel)
+    bot.needs.hunger = hungerLevel
+  end
+  )
+
+  bot.addHandler("thirstEvent", "thirst",
+  function(eventName, thirstLevel)
+    bot.debugMessage("Setting bot.needs.thirst to " .. thirstLevel)
+    bot.needs.thirst = thirstLevel
+  end
+  )
+
+  bot.addHandler("inventoryUpdated", "inventory",
+  function()
+    bot.debugMessage("Implement inventory update handler.")
+  end
+  )
+
+  bot.addHandler("noFood", "noFood",
+  function()
+    bot.debugMessage("Setting bot.items.hasFood = false")
+    bot.items.hasFood = false
+  end
+  )
+
+  bot.addHandler("noWater", "noWater",
+  function()
+    bot.items.hasWater = false
+  end
+  )
+
+  bot.addHandler("scoreUpdated", "score",
+  function()
+    bot.debugMessage("Implement score update handler.")
+  end
+  )
+
+  bot.addHandler("prompt", "prompt",
+  function()
+  end
+  )
 end
 
 --------------------------------------------------------------------------------

--- a/forestbot.lua
+++ b/forestbot.lua
@@ -51,13 +51,6 @@ function bot.think()
 end
 
 --------------------------------------------------------------------------------
--- Run bot.think() after all triggers have finished for the current line.
---------------------------------------------------------------------------------
-function bot.thinkAfterTriggers()
-  tempTimer(0, [[bot.think()]])
-end
-
---------------------------------------------------------------------------------
 -- Resets all bot state to initial values.
 --------------------------------------------------------------------------------
 function bot.reset()
@@ -149,7 +142,7 @@ function bot.addHandler(eventName, handlerName, handlerFunc)
   " to handle \"" .. eventName .. "\" event.")
   bot.handlers[handlerName] = handlerFunc
   registerAnonymousEventHandler(eventName, "bot.handlers." .. handlerName)
-  registerAnonymousEventHandler(eventName, "bot.thinkAfterTriggers")
+  registerAnonymousEventHandler(eventName, "bot.think")
 end
 
 --------------------------------------------------------------------------------

--- a/forestbot.xml
+++ b/forestbot.xml
@@ -34,8 +34,7 @@
                 <regexCodePropertyList/>
                 <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                     <name>mildly hungry</name>
-                    <script>bot.needs.hunger = 1
-bot.think()</script>
+                    <script>raiseEvent(&quot;hungerEvent&quot;, 1)</script>
                     <triggerType>0</triggerType>
                     <conditonLineDelta>0</conditonLineDelta>
                     <mStayOpen>0</mStayOpen>
@@ -55,8 +54,7 @@ bot.think()</script>
                 </Trigger>
                 <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                     <name>hungry</name>
-                    <script>bot.needs.hunger = 2
-bot.think()</script>
+                    <script>raiseEvent(&quot;hungerEvent&quot;, 2)</script>
                     <triggerType>0</triggerType>
                     <conditonLineDelta>0</conditonLineDelta>
                     <mStayOpen>0</mStayOpen>
@@ -76,8 +74,7 @@ bot.think()</script>
                 </Trigger>
                 <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                     <name>ravenous</name>
-                    <script>bot.needs.hunger = 3
-bot.think()</script>
+                    <script>raiseEvent(&quot;hungerEvent&quot;, 3)</script>
                     <triggerType>0</triggerType>
                     <conditonLineDelta>0</conditonLineDelta>
                     <mStayOpen>0</mStayOpen>
@@ -97,8 +94,7 @@ bot.think()</script>
                 </Trigger>
                 <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                     <name>starving to death</name>
-                    <script>bot.needs.hunger = 4
-bot.think()</script>
+                    <script>raiseEvent(&quot;hungerEvent&quot;, 4)</script>
                     <triggerType>0</triggerType>
                     <conditonLineDelta>0</conditonLineDelta>
                     <mStayOpen>0</mStayOpen>
@@ -118,8 +114,7 @@ bot.think()</script>
                 </Trigger>
                 <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                     <name>full</name>
-                    <script>bot.needs.hunger = 0
-bot.think()</script>
+                    <script>raiseEvent(&quot;hungerEvent&quot;, 0)</script>
                     <triggerType>0</triggerType>
                     <conditonLineDelta>0</conditonLineDelta>
                     <mStayOpen>0</mStayOpen>
@@ -157,8 +152,7 @@ bot.think()</script>
                 <regexCodePropertyList/>
                 <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                     <name>throat feels dry</name>
-                    <script>bot.needs.thirst = 1
-bot.think()</script>
+                    <script>raiseEvent(&quot;thirstEvent&quot;, 1)</script>
                     <triggerType>0</triggerType>
                     <conditonLineDelta>0</conditonLineDelta>
                     <mStayOpen>0</mStayOpen>
@@ -178,8 +172,7 @@ bot.think()</script>
                 </Trigger>
                 <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                     <name>thirsty</name>
-                    <script>bot.needs.thirst = 2
-bot.think()</script>
+                    <script>raiseEvent(&quot;thirstEvent&quot;, 2)</script>
                     <triggerType>0</triggerType>
                     <conditonLineDelta>0</conditonLineDelta>
                     <mStayOpen>0</mStayOpen>
@@ -199,8 +192,7 @@ bot.think()</script>
                 </Trigger>
                 <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                     <name>parched</name>
-                    <script>bot.needs.thirst = 3
-bot.think()</script>
+                    <script>raiseEvent(&quot;thirstEvent&quot;, 3)</script>
                     <triggerType>0</triggerType>
                     <conditonLineDelta>0</conditonLineDelta>
                     <mStayOpen>0</mStayOpen>
@@ -220,8 +212,7 @@ bot.think()</script>
                 </Trigger>
                 <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                     <name>dying of thirst</name>
-                    <script>bot.needs.thirst = 4
-bot.think()</script>
+                    <script>raiseEvent(&quot;thirstEvent&quot;, 4)</script>
                     <triggerType>0</triggerType>
                     <conditonLineDelta>0</conditonLineDelta>
                     <mStayOpen>0</mStayOpen>
@@ -241,8 +232,7 @@ bot.think()</script>
                 </Trigger>
                 <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                     <name>quenched</name>
-                    <script>bot.needs.thirst = 0
-bot.think()</script>
+                    <script>raiseEvent(&quot;thirstEvent&quot;, 0)</script>
                     <triggerType>0</triggerType>
                     <conditonLineDelta>39</conditonLineDelta>
                     <mStayOpen>0</mStayOpen>
@@ -426,7 +416,7 @@ bot.items.encumbrance = matches[3]</script>
                     <script>bot.items.numItems = tonumber(matches[2])
 bot.items.maxItems = tonumber(matches[3])
 disableTrigger(&quot;inventory&quot;)
-bot.think()</script>
+raiseEvent(&quot;inventoryUpdated&quot;)</script>
                     <triggerType>0</triggerType>
                     <conditonLineDelta>0</conditonLineDelta>
                     <mStayOpen>0</mStayOpen>
@@ -447,7 +437,7 @@ bot.think()</script>
             </TriggerGroup>
             <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                 <name>NoFood</name>
-                <script>bot.items.hasFood = false</script>
+                <script>raiseEvent(&quot;noFood&quot;)</script>
                 <triggerType>0</triggerType>
                 <conditonLineDelta>39</conditonLineDelta>
                 <mStayOpen>0</mStayOpen>
@@ -467,7 +457,7 @@ bot.think()</script>
             </Trigger>
             <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                 <name>NoWater</name>
-                <script>bot.items.hasWater = false</script>
+                <script>raiseEvent(&quot;noWater&quot;)</script>
                 <triggerType>0</triggerType>
                 <conditonLineDelta>0</conditonLineDelta>
                 <mStayOpen>0</mStayOpen>
@@ -490,30 +480,7 @@ bot.think()</script>
                 </regexCodePropertyList>
             </Trigger>
         </TriggerGroup>
-        <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
-            <name>init</name>
-            <script>-- will run on first login to &quot;the forests edge&quot;
-echo(&quot;preinit&quot;)
-dofile(os.getenv(&quot;forestbot_path&quot;)..&quot;/forestbot.lua&quot;)
-echo(&quot;postinit&quot;)</script>
-            <triggerType>0</triggerType>
-            <conditonLineDelta>0</conditonLineDelta>
-            <mStayOpen>0</mStayOpen>
-            <mCommand></mCommand>
-            <packageName></packageName>
-            <mFgColor>#ff0000</mFgColor>
-            <mBgColor>#ffff00</mBgColor>
-            <mSoundFile></mSoundFile>
-            <colorTriggerFgColor>#000000</colorTriggerFgColor>
-            <colorTriggerBgColor>#000000</colorTriggerBgColor>
-            <regexCodeList>
-                <string>http://www.theforestsedge.com</string>
-            </regexCodeList>
-            <regexCodePropertyList>
-                <integer>0</integer>
-            </regexCodePropertyList>
-        </Trigger>
-        <TriggerGroup isActive="no" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+        <TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
             <name>score</name>
             <script></script>
             <triggerType>0</triggerType>
@@ -550,7 +517,7 @@ echo(&quot;postinit&quot;)</script>
             </Trigger>
             <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                 <name>cleanup</name>
-                <script>disableTrigger(&quot;score&quot;)</script>
+                <script>raiseEvent(&quot;scoreUpdated&quot;)</script>
                 <triggerType>0</triggerType>
                 <conditonLineDelta>0</conditonLineDelta>
                 <mStayOpen>0</mStayOpen>
@@ -594,6 +561,7 @@ bot.status.maxEnergy = tonumber(matches[5])
 bot.status.moves = tonumber(matches[6])
 bot.status.maxMoves = tonumber(matches[7])
 bot.status.xp = tonumber(matches[8])
+raiseEvent(&quot;prompt&quot;)
 
 -- prompt ?p'-- MORE -- '&lt;%f?f|%h/%Hhp %e/%Ee ?m'[%m/%Mmv]'!m'%v/%Vmv' %xxp ?b'%c'!b'%d'&gt;</script>
             <triggerType>0</triggerType>
@@ -611,6 +579,29 @@ bot.status.xp = tonumber(matches[8])
             </regexCodeList>
             <regexCodePropertyList>
                 <integer>1</integer>
+            </regexCodePropertyList>
+        </Trigger>
+        <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+            <name>init</name>
+            <script>-- will run on first login to &quot;the forests edge&quot;
+echo(&quot;preinit&quot;)
+dofile(os.getenv(&quot;forestbot_path&quot;)..&quot;/forestbot.lua&quot;)
+echo(&quot;postinit&quot;)</script>
+            <triggerType>0</triggerType>
+            <conditonLineDelta>0</conditonLineDelta>
+            <mStayOpen>0</mStayOpen>
+            <mCommand></mCommand>
+            <packageName></packageName>
+            <mFgColor>#ff0000</mFgColor>
+            <mBgColor>#ffff00</mBgColor>
+            <mSoundFile></mSoundFile>
+            <colorTriggerFgColor>#000000</colorTriggerFgColor>
+            <colorTriggerBgColor>#000000</colorTriggerBgColor>
+            <regexCodeList>
+                <string>http://www.theforestsedge.com</string>
+            </regexCodeList>
+            <regexCodePropertyList>
+                <integer>0</integer>
             </regexCodePropertyList>
         </Trigger>
     </TriggerPackage>

--- a/forestbot.xml
+++ b/forestbot.xml
@@ -804,6 +804,116 @@ raiseEvent(&quot;someoneIsDEAD&quot;, string.lower(string.trim(matches[2])))</sc
                 </regexCodePropertyList>
             </Trigger>
         </TriggerGroup>
+        <TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+            <name>equipment</name>
+            <script></script>
+            <triggerType>0</triggerType>
+            <conditonLineDelta>0</conditonLineDelta>
+            <mStayOpen>0</mStayOpen>
+            <mCommand></mCommand>
+            <packageName></packageName>
+            <mFgColor>#ff0000</mFgColor>
+            <mBgColor>#ffff00</mBgColor>
+            <mSoundFile></mSoundFile>
+            <colorTriggerFgColor>#000000</colorTriggerFgColor>
+            <colorTriggerBgColor>#000000</colorTriggerBgColor>
+            <regexCodeList/>
+            <regexCodePropertyList/>
+            <TriggerGroup isActive="no" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                <name>refresh equipment</name>
+                <script></script>
+                <triggerType>0</triggerType>
+                <conditonLineDelta>0</conditonLineDelta>
+                <mStayOpen>0</mStayOpen>
+                <mCommand></mCommand>
+                <packageName></packageName>
+                <mFgColor>#ff0000</mFgColor>
+                <mBgColor>#ffff00</mBgColor>
+                <mSoundFile></mSoundFile>
+                <colorTriggerFgColor>#000000</colorTriggerFgColor>
+                <colorTriggerBgColor>#000000</colorTriggerBgColor>
+                <regexCodeList/>
+                <regexCodePropertyList/>
+                <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                    <name>enable equipment</name>
+                    <script>enableTrigger(&quot;equipment line&quot;)</script>
+                    <triggerType>0</triggerType>
+                    <conditonLineDelta>0</conditonLineDelta>
+                    <mStayOpen>0</mStayOpen>
+                    <mCommand></mCommand>
+                    <packageName></packageName>
+                    <mFgColor>#ff0000</mFgColor>
+                    <mBgColor>#ffff00</mBgColor>
+                    <mSoundFile></mSoundFile>
+                    <colorTriggerFgColor>#000000</colorTriggerFgColor>
+                    <colorTriggerBgColor>#000000</colorTriggerBgColor>
+                    <regexCodeList>
+                        <string>---- --------      -----   ----                                       ---------</string>
+                    </regexCodeList>
+                    <regexCodePropertyList>
+                        <integer>3</integer>
+                    </regexCodePropertyList>
+                </Trigger>
+                <Trigger isActive="no" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="yes" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                    <name>equipment line</name>
+                    <script>if not (matches[2] == &quot;---- --------&quot;) then
+  if #matches == 5 then
+    bot.items.currentEqLayer = matches[2]
+    bot.items.equipment[#bot.items.equipment + 1] = {matches[2],
+                                                     matches[3],
+                                                     matches[4],
+                                                     matches[5]}
+  elseif #matches == 4 then
+    bot.items.equipment[#bot.items.equipment + 1] = {bot.items.currentEqLayer,
+                                                     matches[2],
+                                                     matches[3],
+                                                     matches[4]}
+  end
+end</script>
+                    <triggerType>0</triggerType>
+                    <conditonLineDelta>0</conditonLineDelta>
+                    <mStayOpen>0</mStayOpen>
+                    <mCommand></mCommand>
+                    <packageName></packageName>
+                    <mFgColor>#ff0000</mFgColor>
+                    <mBgColor>#ffff00</mBgColor>
+                    <mSoundFile></mSoundFile>
+                    <colorTriggerFgColor>#000000</colorTriggerFgColor>
+                    <colorTriggerBgColor>#000000</colorTriggerBgColor>
+                    <regexCodeList>
+                        <string>^(\S+(?:\s\S+)*)\s\s+(\S+)\s+(\S+(?:\s\S+)*)\s+(\S+(?:\s\S+)*)$</string>
+                        <string>^\s\s+(\S+)\s+(\S+(?:\s\S+)*)\s+(\S+(?:\s\S+)*)$</string>
+                    </regexCodeList>
+                    <regexCodePropertyList>
+                        <integer>1</integer>
+                        <integer>1</integer>
+                    </regexCodePropertyList>
+                </Trigger>
+                <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="yes" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                    <name>disable equipment</name>
+                    <script>bot.items.wornWeight = tonumber(matches[2])
+disableTrigger(&quot;equipment line&quot;)
+disableTrigger(&quot;refresh equipment&quot;)
+raiseEvent(&quot;equipmentUpdated&quot;)</script>
+                    <triggerType>0</triggerType>
+                    <conditonLineDelta>0</conditonLineDelta>
+                    <mStayOpen>0</mStayOpen>
+                    <mCommand></mCommand>
+                    <packageName></packageName>
+                    <mFgColor>#ff0000</mFgColor>
+                    <mBgColor>#ffff00</mBgColor>
+                    <mSoundFile></mSoundFile>
+                    <colorTriggerFgColor>#000000</colorTriggerFgColor>
+                    <colorTriggerBgColor>#000000</colorTriggerBgColor>
+                    <regexCodeList>
+                        <string>^Weight: ([0-9.]+) lbs$</string>
+                    </regexCodeList>
+                    <regexCodePropertyList>
+                        <integer>1</integer>
+                    </regexCodePropertyList>
+                </Trigger>
+            </TriggerGroup>
+        </TriggerGroup>
     </TriggerPackage>
     <TimerPackage>
         <Timer isActive="yes" isFolder="no" isTempTimer="no" isOffsetTimer="no">

--- a/forestbot.xml
+++ b/forestbot.xml
@@ -743,7 +743,7 @@ raiseEvent(&quot;someoneIsDEAD&quot;, string.lower(string.trim(matches[2])))</sc
                 <colorTriggerFgColor>#000000</colorTriggerFgColor>
                 <colorTriggerBgColor>#000000</colorTriggerBgColor>
                 <regexCodeList>
-                    <string>You have been killed!</string>
+                    <string>You have been KILLED!!</string>
                 </regexCodeList>
                 <regexCodePropertyList>
                     <integer>3</integer>
@@ -856,7 +856,7 @@ raiseEvent(&quot;someoneIsDEAD&quot;, string.lower(string.trim(matches[2])))</sc
                         <integer>3</integer>
                     </regexCodePropertyList>
                 </Trigger>
-                <Trigger isActive="no" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="yes" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                <Trigger isActive="no" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                     <name>equipment line</name>
                     <script>if not (matches[2] == &quot;---- --------&quot;) then
   if #matches == 5 then
@@ -891,7 +891,7 @@ end</script>
                         <integer>1</integer>
                     </regexCodePropertyList>
                 </Trigger>
-                <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="yes" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                     <name>disable equipment</name>
                     <script>bot.items.wornWeight = tonumber(matches[2])
 disableTrigger(&quot;equipment line&quot;)
@@ -961,6 +961,13 @@ raiseEvent(&quot;equipmentUpdated&quot;)</script>
             <command></command>
             <packageName></packageName>
             <regex>testIdent</regex>
+        </Alias>
+        <Alias isActive="yes" isFolder="no">
+            <name>test equipment</name>
+            <script>bot.functions.updateEquipment()</script>
+            <command></command>
+            <packageName></packageName>
+            <regex>^testEq</regex>
         </Alias>
     </AliasPackage>
     <ActionPackage/>

--- a/forestbot.xml
+++ b/forestbot.xml
@@ -327,7 +327,7 @@ bot.items.coinsWeight = tonumber(matches[3])
                     <regexCodePropertyList>
                         <integer>3</integer>
                     </regexCodePropertyList>
-                    <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="yes" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                    <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                         <name>one-item line</name>
                         <script>bot.items.inventory[#bot.items.inventory + 1] = {matches[2], tonumber(matches[3]), tonumber(matches[4])}
 </script>
@@ -342,7 +342,7 @@ bot.items.coinsWeight = tonumber(matches[3])
                         <colorTriggerFgColor>#000000</colorTriggerFgColor>
                         <colorTriggerBgColor>#000000</colorTriggerBgColor>
                         <regexCodeList>
-                            <string>^((?:\s?\S+)+)\s+(\d+)\s+([0-9.]+)</string>
+                            <string>^((?:\s?\S+)+)\s+(\d+)\s+([0-9.]+)\s*$</string>
                         </regexCodeList>
                         <regexCodePropertyList>
                             <integer>1</integer>
@@ -415,7 +415,7 @@ bot.items.encumbrance = matches[3]</script>
                     <name>number</name>
                     <script>bot.items.numItems = tonumber(matches[2])
 bot.items.maxItems = tonumber(matches[3])
-disableTrigger(&quot;inventory&quot;)
+disableTrigger(&quot;refresh inventory&quot;)
 raiseEvent(&quot;inventoryUpdated&quot;)</script>
                     <triggerType>0</triggerType>
                     <conditonLineDelta>0</conditonLineDelta>
@@ -480,7 +480,7 @@ raiseEvent(&quot;inventoryUpdated&quot;)</script>
                 </regexCodePropertyList>
             </Trigger>
         </TriggerGroup>
-        <TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+        <TriggerGroup isActive="no" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
             <name>score</name>
             <script></script>
             <triggerType>0</triggerType>
@@ -517,7 +517,8 @@ raiseEvent(&quot;inventoryUpdated&quot;)</script>
             </Trigger>
             <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
                 <name>cleanup</name>
-                <script>raiseEvent(&quot;scoreUpdated&quot;)</script>
+                <script>disableTrigger(&quot;score&quot;)
+raiseEvent(&quot;scoreUpdated&quot;)</script>
                 <triggerType>0</triggerType>
                 <conditonLineDelta>0</conditonLineDelta>
                 <mStayOpen>0</mStayOpen>
@@ -561,7 +562,6 @@ bot.status.maxEnergy = tonumber(matches[5])
 bot.status.moves = tonumber(matches[6])
 bot.status.maxMoves = tonumber(matches[7])
 bot.status.xp = tonumber(matches[8])
-raiseEvent(&quot;prompt&quot;)
 
 -- prompt ?p'-- MORE -- '&lt;%f?f|%h/%Hhp %e/%Ee ?m'[%m/%Mmv]'!m'%v/%Vmv' %xxp ?b'%c'!b'%d'&gt;</script>
             <triggerType>0</triggerType>
@@ -575,7 +575,7 @@ raiseEvent(&quot;prompt&quot;)
             <colorTriggerFgColor>#000000</colorTriggerFgColor>
             <colorTriggerBgColor>#000000</colorTriggerBgColor>
             <regexCodeList>
-                <string>^(?:-- MORE -- )?&lt;[A-Za-z]*\|?(\d*)\/(\d*)hp (\d*)\/(\d*)e \[?(\d*)/(\d*)mv\]? (\d*)xp(?: (\d*)\/(\d*)hp)?.*&gt;</string>
+                <string>^(?:-- MORE -- )?&lt;[A-Za-z]*\|?(\d*)\/(\d*)hp (\d*)\/(\d*)e \[?(\d*)/(\d*)mv\]? ([-0-9]+)xp(?: (\d*)\/(\d*)hp)?.*&gt;</string>
             </regexCodeList>
             <regexCodePropertyList>
                 <integer>1</integer>
@@ -604,6 +604,150 @@ echo(&quot;postinit&quot;)</script>
                 <integer>0</integer>
             </regexCodePropertyList>
         </Trigger>
+        <TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+            <name>combat</name>
+            <script></script>
+            <triggerType>0</triggerType>
+            <conditonLineDelta>0</conditonLineDelta>
+            <mStayOpen>0</mStayOpen>
+            <mCommand></mCommand>
+            <packageName></packageName>
+            <mFgColor>#ff0000</mFgColor>
+            <mBgColor>#ffff00</mBgColor>
+            <mSoundFile></mSoundFile>
+            <colorTriggerFgColor>#000000</colorTriggerFgColor>
+            <colorTriggerBgColor>#000000</colorTriggerBgColor>
+            <regexCodeList/>
+            <regexCodePropertyList/>
+            <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="yes" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                <name>leapsToAttack</name>
+                <script>raiseEvent(&quot;leapsToAttack&quot;,
+           string.lower(string.trim(matches[2])),
+           string.lower(string.trim(matches[3])))</script>
+                <triggerType>0</triggerType>
+                <conditonLineDelta>0</conditonLineDelta>
+                <mStayOpen>0</mStayOpen>
+                <mCommand></mCommand>
+                <packageName></packageName>
+                <mFgColor>#ff0000</mFgColor>
+                <mBgColor>#ffff00</mBgColor>
+                <mSoundFile></mSoundFile>
+                <colorTriggerFgColor>#000000</colorTriggerFgColor>
+                <colorTriggerBgColor>#000000</colorTriggerBgColor>
+                <regexCodeList>
+                    <string>(.+) leaps? to attack (.+)!$</string>
+                </regexCodeList>
+                <regexCodePropertyList>
+                    <integer>1</integer>
+                </regexCodePropertyList>
+            </Trigger>
+            <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                <name>counterattacks</name>
+                <script>raiseEvent(&quot;counterattacks&quot;,
+           string.lower(string.trim(matches[2])),
+           string.lower(string.trim(matches[3])))</script>
+                <triggerType>0</triggerType>
+                <conditonLineDelta>0</conditonLineDelta>
+                <mStayOpen>0</mStayOpen>
+                <mCommand></mCommand>
+                <packageName></packageName>
+                <mFgColor>#ff0000</mFgColor>
+                <mBgColor>#ffff00</mBgColor>
+                <mSoundFile></mSoundFile>
+                <colorTriggerFgColor>#000000</colorTriggerFgColor>
+                <colorTriggerBgColor>#000000</colorTriggerBgColor>
+                <regexCodeList>
+                    <string>(.+) counterattacks? (.+)!$</string>
+                </regexCodeList>
+                <regexCodePropertyList>
+                    <integer>1</integer>
+                </regexCodePropertyList>
+            </Trigger>
+            <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                <name>someoneFled</name>
+                <script>-- TODO: This could also be a player fleeing. The trigger should differentiate
+raiseEvent(&quot;someoneFled&quot;,
+           string.lower(string.trim(matches[2])),
+           string.lower(string.trim(matches[3])))</script>
+                <triggerType>0</triggerType>
+                <conditonLineDelta>0</conditonLineDelta>
+                <mStayOpen>0</mStayOpen>
+                <mCommand></mCommand>
+                <packageName></packageName>
+                <mFgColor>#ff0000</mFgColor>
+                <mBgColor>#ffff00</mBgColor>
+                <mSoundFile></mSoundFile>
+                <colorTriggerFgColor>#000000</colorTriggerFgColor>
+                <colorTriggerBgColor>#000000</colorTriggerBgColor>
+                <regexCodeList>
+                    <string>(.+) blindly flees (\w+).$</string>
+                </regexCodeList>
+                <regexCodePropertyList>
+                    <integer>1</integer>
+                </regexCodePropertyList>
+            </Trigger>
+            <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                <name>someoneIsDEAD</name>
+                <script>-- TODO: This may detect a player's death as well as an npc.
+raiseEvent(&quot;someoneIsDEAD&quot;, string.lower(string.trim(matches[2])))</script>
+                <triggerType>0</triggerType>
+                <conditonLineDelta>0</conditonLineDelta>
+                <mStayOpen>0</mStayOpen>
+                <mCommand></mCommand>
+                <packageName></packageName>
+                <mFgColor>#ff0000</mFgColor>
+                <mBgColor>#ffff00</mBgColor>
+                <mSoundFile></mSoundFile>
+                <colorTriggerFgColor>#000000</colorTriggerFgColor>
+                <colorTriggerBgColor>#000000</colorTriggerBgColor>
+                <regexCodeList>
+                    <string>(.+) is DEAD!!$</string>
+                </regexCodeList>
+                <regexCodePropertyList>
+                    <integer>1</integer>
+                </regexCodePropertyList>
+            </Trigger>
+            <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                <name>botFled</name>
+                <script>raiseEvent(&quot;botFled&quot;, string.lower(string.trim(matches[2])))</script>
+                <triggerType>0</triggerType>
+                <conditonLineDelta>0</conditonLineDelta>
+                <mStayOpen>0</mStayOpen>
+                <mCommand></mCommand>
+                <packageName></packageName>
+                <mFgColor>#ff0000</mFgColor>
+                <mBgColor>#ffff00</mBgColor>
+                <mSoundFile></mSoundFile>
+                <colorTriggerFgColor>#000000</colorTriggerFgColor>
+                <colorTriggerBgColor>#000000</colorTriggerBgColor>
+                <regexCodeList>
+                    <string>You flee (\w+).$</string>
+                </regexCodeList>
+                <regexCodePropertyList>
+                    <integer>1</integer>
+                </regexCodePropertyList>
+            </Trigger>
+            <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                <name>botDeath</name>
+                <script>raiseEvent(&quot;botDeath&quot;)</script>
+                <triggerType>0</triggerType>
+                <conditonLineDelta>0</conditonLineDelta>
+                <mStayOpen>0</mStayOpen>
+                <mCommand></mCommand>
+                <packageName></packageName>
+                <mFgColor>#ff0000</mFgColor>
+                <mBgColor>#ffff00</mBgColor>
+                <mSoundFile></mSoundFile>
+                <colorTriggerFgColor>#000000</colorTriggerFgColor>
+                <colorTriggerBgColor>#000000</colorTriggerBgColor>
+                <regexCodeList>
+                    <string>You have been killed!</string>
+                </regexCodeList>
+                <regexCodePropertyList>
+                    <integer>3</integer>
+                </regexCodePropertyList>
+            </Trigger>
+        </TriggerGroup>
     </TriggerPackage>
     <TimerPackage>
         <Timer isActive="yes" isFolder="no" isTempTimer="no" isOffsetTimer="no">

--- a/forestbot.xml
+++ b/forestbot.xml
@@ -128,8 +128,10 @@
                     <regexCodeList>
                         <string>You no longer feel hungry.$</string>
                         <string>You feel full.$</string>
+                        <string>You are too full to eat more.$</string>
                     </regexCodeList>
                     <regexCodePropertyList>
+                        <integer>1</integer>
                         <integer>1</integer>
                         <integer>1</integer>
                     </regexCodePropertyList>

--- a/forestbot.xml
+++ b/forestbot.xml
@@ -748,6 +748,62 @@ raiseEvent(&quot;someoneIsDEAD&quot;, string.lower(string.trim(matches[2])))</sc
                 </regexCodePropertyList>
             </Trigger>
         </TriggerGroup>
+        <TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+            <name>location</name>
+            <script></script>
+            <triggerType>0</triggerType>
+            <conditonLineDelta>0</conditonLineDelta>
+            <mStayOpen>0</mStayOpen>
+            <mCommand></mCommand>
+            <packageName></packageName>
+            <mFgColor>#ff0000</mFgColor>
+            <mBgColor>#ffff00</mBgColor>
+            <mSoundFile></mSoundFile>
+            <colorTriggerFgColor>#000000</colorTriggerFgColor>
+            <colorTriggerBgColor>#000000</colorTriggerBgColor>
+            <regexCodeList/>
+            <regexCodePropertyList/>
+            <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                <name>newRoom</name>
+                <script>raiseEvent(&quot;newRoom&quot;, tonumber(matches[2]))</script>
+                <triggerType>0</triggerType>
+                <conditonLineDelta>0</conditonLineDelta>
+                <mStayOpen>0</mStayOpen>
+                <mCommand></mCommand>
+                <packageName></packageName>
+                <mFgColor>#ff0000</mFgColor>
+                <mBgColor>#ffff00</mBgColor>
+                <mSoundFile></mSoundFile>
+                <colorTriggerFgColor>#000000</colorTriggerFgColor>
+                <colorTriggerBgColor>#000000</colorTriggerBgColor>
+                <regexCodeList>
+                    <string>Room #(\d+)$</string>
+                </regexCodeList>
+                <regexCodePropertyList>
+                    <integer>1</integer>
+                </regexCodePropertyList>
+            </Trigger>
+            <Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+                <name>Typo Spam</name>
+                <script>deleteLine()</script>
+                <triggerType>0</triggerType>
+                <conditonLineDelta>0</conditonLineDelta>
+                <mStayOpen>0</mStayOpen>
+                <mCommand></mCommand>
+                <packageName></packageName>
+                <mFgColor>#ff0000</mFgColor>
+                <mBgColor>#ffff00</mBgColor>
+                <mSoundFile></mSoundFile>
+                <colorTriggerFgColor>#000000</colorTriggerFgColor>
+                <colorTriggerBgColor>#000000</colorTriggerBgColor>
+                <regexCodeList>
+                    <string>What typo do you wish to report?</string>
+                </regexCodeList>
+                <regexCodePropertyList>
+                    <integer>3</integer>
+                </regexCodePropertyList>
+            </Trigger>
+        </TriggerGroup>
     </TriggerPackage>
     <TimerPackage>
         <Timer isActive="yes" isFolder="no" isTempTimer="no" isOffsetTimer="no">


### PR DESCRIPTION
This pull request now closes #4 . I ran into the same issue as before where bot.think() was probably going to get called more than once for an input line from the mud. In this case, it was because more than one trigger was firing on the same line of text, to accomplish different things for different parts of the system: for example, if you see "You have been killed!", you want to set bot.status.weak = true for the death-weakness and you want to set bot.status.inCombat = false, and do various things to combat-related variables. This would lead to either:
- We have multiple triggers for the same line, to keep status-stuff separate from combat-stuff, which could cause bot.think() to be called by each of the triggers, or multiple times per line, or
- We have only one trigger for a given type of input line, and it does all updates related to that line (combat, status, etc.). This could end up making it hard to find where a variable was updated.

Events allow us to decouple these nicely: We can trigger off each type of line only once, and trigger the related event (guaranteeing that only one event will fire per input line). We can then register as many handlers as we need, with separate handlers for different concepts. One handler for "botDiedEvent" can set status.stance to "sitting" and status.weak to "true", while another resets all the state for the combat system.
